### PR TITLE
Added devcontainer with .Net 9 needed to build

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# Buenaventura Dev Container Configuration
+
+This directory contains the configuration for GitHub Codespaces and VS Code Dev Containers to ensure a consistent development environment.
+
+## Files
+
+- `devcontainer.json` - Main configuration file that sets up:
+  - .NET 9.0 SDK
+  - Required VS Code extensions
+  - Port forwarding for the web application
+  - Automatic package restore after container creation
+
+## Usage
+
+When you create a new GitHub Codespace or open this repository in VS Code with the Dev Containers extension, it will automatically:
+
+1. Create a container with .NET 9.0 SDK
+2. Install the required VS Code extensions
+3. Restore NuGet packages
+4. Forward ports 5000 and 5001 for the web application
+
+## Building the Project
+
+After the container is created, you can build the project with:
+
+```bash
+dotnet build
+```
+
+## Running the Application
+
+To run the application:
+
+```bash
+dotnet run --project Buenaventura
+```
+
+The application will be available at `https://localhost:5001` or `http://localhost:5000`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Buenaventura Development Environment",
+  "image": "mcr.microsoft.com/dotnet/sdk:9.0",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "ms-vscode.vscode-json"
+      ]
+    }
+  },
+  "forwardPorts": [5000, 5001],
+  "postCreateCommand": "dotnet restore",
+  "remoteUser": "root"
+}


### PR DESCRIPTION
This pull request introduces a development container configuration for the Buenaventura project, enabling a standardized development environment with GitHub Codespaces and VS Code Dev Containers. The changes include documentation and setup files that streamline the process of building and running the application.

### Development Environment Setup:

* [`.devcontainer/README.md`](diffhunk://#diff-0f9548cbce10dbdef0b86d783ed0727a4ac1061fc71cb549b5dbd400705c71fdR1-R38): Added a README file explaining the purpose of the development container, detailing the setup process, and providing instructions for building and running the project using `.NET 9.0 SDK`.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R17): Added the main configuration file for the development container, specifying the `.NET 9.0 SDK` image, required VS Code extensions, port forwarding, automatic package restoration, and root user configuration.